### PR TITLE
[#3] Add raising error if #combine is used with unsupported adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 group :test do
   gem "simplecov", "0.13.0", require: false
-  gem "minitest", "5.10.2"
+  gem "rspec", "3.7.0"
   gem "rake", "12.0.0"
   gem "pry", "0.10.4"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,28 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.1)
+    diff-lcs (1.3)
     docile (1.1.5)
     json (2.1.0)
     method_source (0.8.2)
-    minitest (5.10.2)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rake (12.0.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
     sequel (5.5.0)
     simplecov (0.13.0)
       docile (~> 1.1.0)
@@ -29,9 +42,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (= 5.10.2)
   pry (= 0.10.4)
   rake (= 12.0.0)
+  rspec (= 3.7.0)
   sequel-combine!
   simplecov (= 0.13.0)
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,11 @@ require "rake"
 require "rake/testtask"
 require "rake/clean"
 require "bundler"
+require 'rspec/core/rake_task'
 
 Bundler.require(:default, :test)
+
+RSpec::Core::RakeTask.new(:spec)
 
 task default: [:spec]
 
@@ -23,9 +26,4 @@ end
 desc "Publish the gem to rubygems.org"
 task release: [:package] do
   sh %{#{FileUtils::RUBY} -S gem push ./#{NAME}-#{VERSION.call}.gem}
-end
-
-task :spec do
-  spec_files = Dir["spec/**/*_spec.rb"].to_a.join(" ")
-  sh "#{FileUtils::RUBY} -e \"ARGV.each { |f| load f }\" #{spec_files}"
 end

--- a/lib/sequel/extensions/combine.rb
+++ b/lib/sequel/extensions/combine.rb
@@ -9,6 +9,8 @@ module Sequel
       AGGREGATED_ROW_ALIAS = :ROW
 
       def combine(options)
+        raise Sequel::DatabaseError, "Invalid adapter. PostgreSQL driver not found." unless Sequel::Postgres::USES_PG
+        
         column_mappings = options.map { |type, relations| combine_columns(type, relations) }
         column_mapping = column_mappings.reduce({}, :merge)
         select_append do

--- a/spec/sequel/exstensions/combine_spec.rb
+++ b/spec/sequel/exstensions/combine_spec.rb
@@ -3,70 +3,108 @@ require_relative "../../spec_helper"
 Sequel.extension :combine
 
 describe Sequel::Extensions::Combine do
-  before do
-    Sequel::Dataset.send(:include, Sequel::Extensions::Combine)
-    @db = Sequel.mock
-  end
+  let(:db) { Sequel.mock }
 
-  describe "one" do
-    it "generates combining sql" do
-      combine = @db[:users].combine(one: { group: [@db[:groups], group_id: :id]})
-      combine.sql.must_equal "SELECT *, (SELECT row_to_json(ROW) FROM (SELECT * FROM groups WHERE (group_id = id)) AS ROW) AS group FROM users"
+  before { Sequel::Dataset.send(:include, Sequel::Extensions::Combine) }
+
+  context "when adapter is Postgres" do
+    before { stub_const("Sequel::Postgres::USES_PG", true) }
+
+    describe "one" do
+      subject do 
+        db[:users].combine(
+          one: { group: [db[:groups], group_id: :id]}
+        )
+      end
+
+      it "generates combining sql" do
+        expect(subject.sql).to eql "SELECT *, (SELECT row_to_json(ROW) FROM (SELECT * FROM groups WHERE (group_id = id)) AS ROW) AS group FROM users"
+      end
+
+      describe "with multiple combines" do
+        subject do
+          db[:users].combine(
+            one: {
+              group: [db[:groups], group_id: :id],
+              company: [db[:companies], company_id: :id],
+            },
+          )
+        end
+
+        it "generates proper query" do
+          expect(subject.sql).to eql "SELECT *, (SELECT row_to_json(ROW) FROM (SELECT * FROM groups WHERE (group_id = id)) AS ROW) AS group, (SELECT row_to_json(ROW) FROM (SELECT * FROM companies WHERE (company_id = id)) AS ROW) AS company FROM users"
+        end
+      end
     end
 
-    describe "with multiple combines" do
-      it "generates proper query" do
-        combine = @db[:users].combine(
-          one: {
-            group: [@db[:groups], group_id: :id],
-            company: [@db[:companies], company_id: :id],
-          },
-        )
-        combine.sql.must_equal "SELECT *, (SELECT row_to_json(ROW) FROM (SELECT * FROM groups WHERE (group_id = id)) AS ROW) AS group, (SELECT row_to_json(ROW) FROM (SELECT * FROM companies WHERE (company_id = id)) AS ROW) AS company FROM users"
+    describe "many" do
+      subject do 
+        db[:groups].combine(
+          many: { users: [db[:users], id: :group_id] }
+        ) 
+      end
+      it "generates combining query" do
+        expect(subject.sql).to eql "SELECT *, (SELECT COALESCE(array_to_json(array_agg(row_to_json(ROW))), '[]') FROM (SELECT * FROM users WHERE (id = group_id)) AS ROW) AS users FROM groups"
+      end
+
+      describe "with multiple combines" do
+        subject do
+          db[:users].combine(
+            many: {
+              tasks: [db[:tasks], id: :user_id],
+              roles: [db[:roles], id: :user_id],
+            },
+          )
+        end
+
+        it "generates proper query" do
+          expect(subject.sql).to eql "SELECT *, (SELECT COALESCE(array_to_json(array_agg(row_to_json(ROW))), '[]') FROM (SELECT * FROM tasks WHERE (id = user_id)) AS ROW) AS tasks, (SELECT COALESCE(array_to_json(array_agg(row_to_json(ROW))), '[]') FROM (SELECT * FROM roles WHERE (id = user_id)) AS ROW) AS roles FROM users"
+        end
+      end
+
+      describe "with many and one in the same combine" do
+        subject do
+          db[:users].combine(
+            one: { company: [db[:companies], company_id: :id]},
+            many: { roles: [db[:roles], id: :user_id]},
+          )
+        end
+
+        it "generates proper query" do
+          expect(subject.sql).to eql "SELECT *, (SELECT row_to_json(ROW) FROM (SELECT * FROM companies WHERE (company_id = id)) AS ROW) AS company, (SELECT COALESCE(array_to_json(array_agg(row_to_json(ROW))), '[]') FROM (SELECT * FROM roles WHERE (id = user_id)) AS ROW) AS roles FROM users"
+        end
+      end
+
+      describe "with nested combines" do
+        subject do
+          db[:projects].combine(
+            many: {
+              users: [
+                db[:users].combine(one: { city: [db[:cities], city_id: :id] }),
+                id: :project_id,
+              ],
+            },
+          )
+        end
+
+        it "generates the proper query" do
+          expect(subject.sql).to eql "SELECT *, (SELECT COALESCE(array_to_json(array_agg(row_to_json(ROW))), '[]') FROM (SELECT *, (SELECT row_to_json(ROW) FROM (SELECT * FROM cities WHERE (city_id = id)) AS ROW) AS city FROM users WHERE (id = project_id)) AS ROW) AS users FROM projects"
+        end
       end
     end
   end
 
-  describe "many" do
-    it "generates combining query" do
-      combine = @db[:groups].combine(many: { users: [@db[:users], id: :group_id] })
-      combine.sql.must_equal "SELECT *, (SELECT COALESCE(array_to_json(array_agg(row_to_json(ROW))), '[]') FROM (SELECT * FROM users WHERE (id = group_id)) AS ROW) AS users FROM groups"
+  context "when adapter is different" do
+    subject do 
+      db[:users].combine(
+        one: { group: [db[:groups], group_id: :id]}
+      )
     end
 
-    describe "with multiple combines" do
-      it "generates proper query" do
-        combine = @db[:users].combine(
-          many: {
-            tasks: [@db[:tasks], id: :user_id],
-            roles: [@db[:roles], id: :user_id],
-          },
-        )
-        combine.sql.must_equal "SELECT *, (SELECT COALESCE(array_to_json(array_agg(row_to_json(ROW))), '[]') FROM (SELECT * FROM tasks WHERE (id = user_id)) AS ROW) AS tasks, (SELECT COALESCE(array_to_json(array_agg(row_to_json(ROW))), '[]') FROM (SELECT * FROM roles WHERE (id = user_id)) AS ROW) AS roles FROM users"
-      end
-    end
+    before { stub_const("Sequel::Postgres::USES_PG", false) }
 
-    describe "with many and one in the same combine" do
-      it "generates proper query" do
-        combine = @db[:users].combine(
-          one: { company: [@db[:companies], company_id: :id]},
-          many: { roles: [@db[:roles], id: :user_id]},
-        )
-        combine.sql.must_equal "SELECT *, (SELECT row_to_json(ROW) FROM (SELECT * FROM companies WHERE (company_id = id)) AS ROW) AS company, (SELECT COALESCE(array_to_json(array_agg(row_to_json(ROW))), '[]') FROM (SELECT * FROM roles WHERE (id = user_id)) AS ROW) AS roles FROM users"
-      end
-    end
-
-    describe "with nested combines" do
-      it "generates the proper query" do
-        combine = @db[:projects].combine(
-          many: {
-            users: [
-              @db[:users].combine(one: { city: [@db[:cities], city_id: :id] }),
-              id: :project_id,
-            ],
-          },
-        )
-        combine.sql.must_equal "SELECT *, (SELECT COALESCE(array_to_json(array_agg(row_to_json(ROW))), '[]') FROM (SELECT *, (SELECT row_to_json(ROW) FROM (SELECT * FROM cities WHERE (city_id = id)) AS ROW) AS city FROM users WHERE (id = project_id)) AS ROW) AS users FROM projects"
-      end
+    it "raise error" do
+      expect { subject }.to raise_error(Sequel::DatabaseError, "Invalid adapter. PostgreSQL driver not found.")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
-$: << File.dirname(__FILE__)
-$: << File.join(File.dirname(__FILE__), "..", "lib")
-
+require 'bundler/setup'
 require "simplecov"
 SimpleCov.start
 
 require "sequel-combine"
-
-require "minitest/autorun"
-require "minitest/spec"
 require "pry"
+
+Dir['./spec/support/*'].each(&method(:require))
+
+RSpec.configure do |config|
+  config.mock_framework = :rspec
+end


### PR DESCRIPTION
*Migrate specs to Spec

#3 Raising error when #combine is used with unsupported adapter